### PR TITLE
fix: replace smartystreets assertions module

### DIFF
--- a/services/api/go.mod
+++ b/services/api/go.mod
@@ -48,4 +48,5 @@ require (
 )
 
 replace github.com/minio/minio-go/v7 => github.com/minio/minio-go/v7 v7.0.20
+replace github.com/smartystreets/assertions => github.com/smarty/assertions v1.16.0
 replace golang.org/x/sys => golang.org/x/sys v0.26.0


### PR DESCRIPTION
## Summary
- fix go module path for smartystreets/assertions

## Testing
- `GOPROXY=direct go mod tidy` *(fails: CONNECT tunnel failed, response 403)*
- `GOPROXY=direct go test ./...` *(fails: go mod tidy needed)*

------
https://chatgpt.com/codex/tasks/task_e_68a447cfda9c832a837fb4a3c64b21e9